### PR TITLE
Fix wrapMode property

### DIFF
--- a/qfield-plugin-reloader/main.qml
+++ b/qfield-plugin-reloader/main.qml
@@ -48,7 +48,7 @@ Item {
         ColumnLayout {
             Label {
                 width: parent.width
-                wrapMode: Text.WrapText
+                wrapMode: Text.Wrap
                 text: qsTr("Are you sure you want to reload the plugin '%1'?").arg(pluginName)
             }
         }
@@ -79,7 +79,7 @@ Item {
 
             Label {
                 id: labelSelection
-                wrapMode: Text.WrapText
+                wrapMode: Text.Wrap
                 text: qsTr("Select the (app) plugin you would like to reload")
             }
 


### PR DESCRIPTION
When loading plugin reloader, i get error : 
`Unable to assign [undefined] to QQuckText:WrapMode`

Fix with changin `wrapMode: Text.WrapText` to `wrapMode: Text.Wrap`.

Documentation [here](https://doc.qt.io/qt-6/qml-qtquick-text.html#wrapMode-prop)

By the way, thank you so much for your so useful plugin !